### PR TITLE
Update rsdos parser to handle both the original schema and the new version just added to corsaro3

### DIFF
--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -55,6 +55,11 @@ cpdef enum RsdosAttribute:
     ATTR_RSDOS_FIRST_TARGET_PORT = 16
     ATTR_RSDOS_LAST_ATTRIBUTE = 17
 
+cpdef enum RsdosAttributeStirng:
+    ATTR_RSDOS_MAXMIND_CONTINENT = 0
+    ATTR_RSDOS_MAXMIND_COUNTRY = 1
+    ATTR_RSDOS_LAST_STRING_ATTRIBUTE = 2
+
 cdef class AvroRsdos(AvroRecord):
 
     cdef unsigned char *packetcontent

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -49,7 +49,25 @@ cdef class AvroRsdos(AvroRecord):
         self.schemaversion = 1
 
     def __str__(self):
-        return "%u %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u %s %s" % \
+        if self.schemaversion == 1:
+            return "%u v1 %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u ?? ??" % \
+                    (self.attributes_l[<int>ATTR_RSDOS_TIMESTAMP], \
+                     self.attributes_l[<int>ATTR_RSDOS_START_TIME_SEC],
+                     self.attributes_l[<int>ATTR_RSDOS_START_TIME_USEC],
+                     self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_SEC],
+                     self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_USEC],
+                     self.attributes_l[<int>ATTR_RSDOS_TARGET_IP],
+                     self.attributes_l[<int>ATTR_RSDOS_TARGET_PROTOCOL],
+                     self.attributes_l[<int>ATTR_RSDOS_PACKET_LEN],
+                     self.attributes_l[<int>ATTR_RSDOS_ATTACKER_IP_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_ATTACK_PORT_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_TARGET_PORT_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_PACKET_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_BYTE_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_MAX_PPM_INTERVAL],
+                     self.getRsdosPacketSize())
+
+        return "%u v2 %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u %s %s" % \
                 (self.attributes_l[<int>ATTR_RSDOS_TIMESTAMP], \
                  self.attributes_l[<int>ATTR_RSDOS_START_TIME_SEC],
                  self.attributes_l[<int>ATTR_RSDOS_START_TIME_USEC],
@@ -65,8 +83,8 @@ cdef class AvroRsdos(AvroRecord):
                  self.attributes_l[<int>ATTR_RSDOS_BYTE_CNT],
                  self.attributes_l[<int>ATTR_RSDOS_MAX_PPM_INTERVAL],
                  self.getRsdosPacketSize(),
-                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_CONTINENT],
-                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_COUNTRY])
+                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_CONTINENT].decode('utf-8'),
+                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_COUNTRY].decode('utf-8'))
 
     cpdef dict asDict(self):
         cdef dict result
@@ -96,6 +114,8 @@ cdef class AvroRsdos(AvroRecord):
         }
 
         if self.schemaversion == 2:
+            del(result["attacker_count"])
+            result["attacker_slash16_count"] = self.attributes_l[<int>ATTR_RSDOS_ATTACKER_IP_CNT]
             result['first_attack_port'] = self.attributes_l[<int>ATTR_RSDOS_FIRST_ATTACK_PORT]
             result['first_target_port'] = self.attributes_l[<int>ATTR_RSDOS_FIRST_TARGET_PORT]
             result['maxmind_continent'] = self.attributes_s[<int>ATTR_RSDOS_MAXMIND_CONTINENT]


### PR DESCRIPTION
 * Maxmind geo-tags are now made available for schema v2 records
 * Rename "attacker_ip_count" to "attacker_slash16_count" in asDict() for v2 records.