### PR TITLE
Add dumpAvroRecords method and start method error checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ share/python-wheels/
 MANIFEST
 
 .python-version
+
+*.cpp
+*.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-# This software is Copyright (C) 2021 The Regents of the University of
+# This software is Copyright © 2021 The Regents of the University of
 # California. All Rights Reserved. Permission to copy, modify, and distribute
 # this software and its documentation for educational, research and non-profit
 # purposes, without fee, and without a written agreement is hereby granted,
@@ -31,40 +31,3 @@
 # HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
 # OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
 # MODIFICATIONS.
-
-import cython
-from pyavro_stardust.baseavro cimport AvroRecord, AvroReader
-
-cpdef enum Flowtuple3AttributeNum:
-    ATTR_FT3_TIMESTAMP = 0
-    ATTR_FT3_SRC_IP = 1
-    ATTR_FT3_DST_IP = 2
-    ATTR_FT3_SRC_PORT = 3
-    ATTR_FT3_DST_PORT = 4
-    ATTR_FT3_PROTOCOL = 5
-    ATTR_FT3_TTL = 6
-    ATTR_FT3_TCP_FLAGS = 7
-    ATTR_FT3_IP_LEN = 8
-    ATTR_FT3_SYN_LEN = 9
-    ATTR_FT3_SYNWIN_LEN = 10
-    ATTR_FT3_PKT_COUNT = 11
-    ATTR_FT3_ISSPOOFED = 12
-    ATTR_FT3_ISMASSCAN = 13
-    ATTR_FT3_ASN = 14
-
-cpdef enum Flowtuple3AttributeStr:
-    ATTR_FT3_MAXMIND_CONTINENT = 0
-    ATTR_FT3_MAXMIND_COUNTRY = 1
-    ATTR_FT3_NETACQ_CONTINENT = 2
-    ATTR_FT3_NETACQ_COUNTRY = 3
-
-
-cdef class AvroFlowtuple3(AvroRecord):
-    cpdef dict asDict(self)
-
-cdef class AvroFlowtuple3Reader(AvroReader):
-    cdef int _parseNextRecord(self, const unsigned char[:] buf,
-            const unsigned int maxlen)
-
-
-# vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ dist:
 redist: clean dist
 
 install:
-	CYTHONIZE=1 pip install .
+	CYTHONIZE=1 pip3 install .
 
 install-from-source: dist
-	pip install dist/pyavro-stardust-1.0.0.tar.gz
+	pip3 install dist/pyavro-stardust-1.0.0.tar.gz
 
 clean:
 	$(RM) -r build dist src/*.egg-info
@@ -23,5 +23,5 @@ clean:
 	#git clean -fdX
 
 uninstall:
-	pip uninstall pyavro-stardust
+	pip3 uninstall pyavro-stardust
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,20 @@ This package provides an interface for fast processing of the STARDUST avro
 data files using python.
 
 Data formats that are currently supported are:
- * flowtuple data
- * RSDOS attack data --- coming soon
+ * flowtuple v3 data
+ * flowtuple v4 data
+ * RSDOS attack data
 
 ### Installation
 
+Dependencies:
+  * pywandio -- https://github.com/CAIDA/pywandio (note: STARDUST users should
+    already have the python[3]-pywandio package installed on their VM)
+  * cython
+
+
 ```
-make install
+make && make install
 ```
 
 or
@@ -18,3 +25,66 @@ or
 ```
 USE_CYTHON=1 pip install --user .
 ```
+
+### Examples
+Simple example programs that demonstrate the API for each of the
+supported formats can be found in the `examples/` directory.
+
+
+### General Usage
+
+I strongly recommend having the code for one of the examples available
+when you read this section, as it should help clarify much of what is
+being explained here.
+
+---
+
+Step 1: Create an instance of a reader for the data format that you wish to
+read, passing in a valid wandio path to the file that you wish to read
+as a parameter (a swift URI or a path to a file).
+
+Examples of valid reader instances are: `AvroFlowtuple3Reader`,
+`AvroFlowtuple4Reader`, and `AvroRsdosReader`.
+
+Step 2: Invoke the `start()` method for the reader instance.
+
+Step 3: Define a callback method that you wish to be invoked for each Avro
+record that has been read from your input file.
+
+The method must take two arguments: the record itself and a `userarg`
+parameter. The `userarg` parameter provides a way for you to pass in
+additional arguments to the callback method from outside of the scope
+of the callback method.
+
+There are some common methods that are available for any Avro record object:
+ * `asDict()` -- returns all fields in the Avro record as a python dictionary
+    (key = field name, value = field value).
+ * `getNumeric(attributeId)` -- returns the value for a specific field that
+   has a numeric value (e.g. IP address, port, counter, timestamp, etc.)
+ * `getString(attributeId)` -- returns the value for a specific field that has
+   a string value (e.g. a geo-location tag)
+ * `getNumericArray(attributeId)` -- returns a list of values that have been
+   stored in the record as an array of numbers
+
+The attributeIds for each data format are listed on the pyavro-stardust wiki
+at https://github.com/CAIDA/pyavro-stardust/wiki/Supported-Data-Formats
+
+In terms of efficiency, I would recommend using `asDict()` if your callback
+function needs to access more than 3 different fields in the record, as the
+function call overhead of calling methods like `getNumeric()` multiple times
+will quickly add up to exceed the cost of calling `asDict() once and having
+every value available.
+
+Step 4: Invoke the `perAvroRecord()` method on your reader instance, passing
+in your callback function name as the first argument. If your callback is
+going to make use of the `userarg` parameter, then the intended value for
+`userarg` should be passed in as the optional second argument.
+
+This function call will only complete once your callback has been applied to
+every individual Avro record in the input file.
+
+Step 5: Invoke the close() method on your reader instance.
+
+Step 6: Do any final post-processing or output writing that your analysis
+requires.
+

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Data formats that are currently supported are:
 
 ### Installation
 
-Dependencies:
+#### Dependencies
   * pywandio -- https://github.com/CAIDA/pywandio (note: STARDUST users should
     already have the python[3]-pywandio package installed on their VM)
-  * cython
+  * cython -- run `pip install cython`
 
+
+#### Installation command
 
 ```
 make && make install

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ going to make use of the `userarg` parameter, then the intended value for
 This function call will only complete once your callback has been applied to
 every individual Avro record in the input file.
 
-Step 5: Invoke the close() method on your reader instance.
+Step 5: Invoke the `close()` method on your reader instance.
 
 Step 6: Do any final post-processing or output writing that your analysis
 requires.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ at https://github.com/CAIDA/pyavro-stardust/wiki/Supported-Data-Formats
 In terms of efficiency, I would recommend using `asDict()` if your callback
 function needs to access more than 3 different fields in the record, as the
 function call overhead of calling methods like `getNumeric()` multiple times
-will quickly add up to exceed the cost of calling `asDict() once and having
+will quickly add up to exceed the cost of calling `asDict()` once and having
 every value available.
 
 Step 4: Invoke the `perAvroRecord()` method on your reader instance, passing

--- a/examples/flowtuple4-example.py
+++ b/examples/flowtuple4-example.py
@@ -1,4 +1,4 @@
-# Example code that uses the AvroFlowtuple3Reader extension class to
+# Example code that uses the AvroFlowtuple4Reader extension class to
 # count flowtuples via a perFlowtuple callback method
 
 import sys
@@ -17,6 +17,9 @@ sizes = defaultdict(int)
 # Incredibly simple callback that simply increments a global counter for
 # each flowtuple, as well as tracking the number of packets for each
 # IP protocols
+#
+# We also report some stats on the most common TTLs, packet sizes and TCP flag
+# combinations that our flowtuple records contain
 def perFlowtupleCallback(ft, userarg):
     global counter, protocols
     counter += 1

--- a/examples/rsdos-example.py
+++ b/examples/rsdos-example.py
@@ -1,0 +1,35 @@
+# Example code that uses the AvroRsdosReader extension class to count
+# DOS attacks via a perDos callback method
+
+import sys
+from pyavro_stardust.rsdos import AvroRsdosReader, RsdosAttribute, \
+       AvroRsdos
+
+count = 0
+attack_pkts = 0
+
+def perDosCallback(rsdos, userarg):
+    global count, attack_pkts
+
+    count += 1
+    dos = rsdos.asDict()
+    attack_pkts += dos['packet_count']
+
+    # Ideally, we'd do things with the other fields in 'dos' as well,
+    # but this is just intended to be a very simple example
+
+def run():
+    # sys.argv[1] must be a valid wandio path -- e.g. a swift URL or
+    # a path to a file on disk
+    reader = AvroRsdosReader(sys.argv[1])
+    reader.start()
+
+    # This will read all of the attack records and call `perDosCallback` on
+    # each one
+    reader.perAvroRecord(perDosCallback)
+    reader.close()
+
+    # Display our final results
+    print("Attacks", count, "   Packets:", attack_pkts)
+
+run()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 from setuptools import setup, find_packages, Extension
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extensions = [
     Extension('pyavro_stardust.baseavro', ['src/pyavro_stardust/baseavro.pyx'], language="c++"),
     Extension('pyavro_stardust.flowtuple3', ['src/pyavro_stardust/flowtuple3.pyx'], language="c++"),
     Extension('pyavro_stardust.flowtuple4', ['src/pyavro_stardust/flowtuple4.pyx'], language="c++"),
-    #Extension('pyavro_stardust.rsdos', ['src/pyavro_stardust/rsdos.pyx'])
+    Extension('pyavro_stardust.rsdos', ['src/pyavro_stardust/rsdos.pyx'], language="c++")
 ]
 
 CYTHONIZE = bool(int(os.getenv("CYTHONIZE", 0))) and cythonize is not None

--- a/src/pyavro_stardust/baseavro.pxd
+++ b/src/pyavro_stardust/baseavro.pxd
@@ -58,6 +58,7 @@ cdef parsedNumericArrayBlock read_numeric_array(const unsigned char[:] buf,
 
 cdef class AvroRecord:
 
+    cdef public unsigned int schemaversion
     cdef long *attributes_l
     cdef char **attributes_s
     cdef long **attributes_na
@@ -78,9 +79,11 @@ cdef class AvroRecord:
             const unsigned int maxlen, const int attrind)
     cpdef vector[long] getNumericArray(self, const int attrind)
     cpdef void resetRecord(self)
+    cpdef void setSchemaVersion(self, const unsigned int schemaversion)
 
 
 cdef class AvroReader:
+    cdef unsigned int schemaversion
     cdef unsigned int nextblock
     cdef unsigned int unzip_offset
     cdef fh

--- a/src/pyavro_stardust/baseavro.pxd
+++ b/src/pyavro_stardust/baseavro.pxd
@@ -1,3 +1,37 @@
+# This software is Copyright (C) 2021 The Regents of the University of
+# California. All Rights Reserved. Permission to copy, modify, and distribute
+# this software and its documentation for educational, research and non-profit
+# purposes, without fee, and without a written agreement is hereby granted,
+# provided that the above copyright notice, this paragraph and the following
+# three paragraphs appear in all copies. Permission to make commercial use of
+# this software may be obtained by contacting:
+#
+# Office of Innovation and Commercialization
+# 9500 Gilman Drive, Mail Code 0910
+# University of California
+# La Jolla, CA 92093-0910
+# (858) 534-5815
+# invent@ucsd.edu
+#
+# This software program and documentation are copyrighted by The Regents of the
+# University of California. The software program and documentation are supplied
+# "as is", without any accompanying services from The Regents. The Regents does
+# not warrant that the operation of the program will be uninterrupted or
+# error-free. The end-user understands that the program was developed for
+# research purposes and is advised not to rely exclusively on the program for
+# any reason.
+#
+# IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE. THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+# HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
+# OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
 from libcpp.vector cimport vector
 from cpython cimport array
 import array

--- a/src/pyavro_stardust/baseavro.pxd
+++ b/src/pyavro_stardust/baseavro.pxd
@@ -1,4 +1,7 @@
 from libcpp.vector cimport vector
+from cpython cimport array
+import array
+
 
 cdef struct parsedString:
     unsigned int toskip
@@ -14,7 +17,7 @@ cdef struct parsedNumericArrayBlock:
 cdef (unsigned int, long) read_long(const unsigned char[:] buf,
         const unsigned int maxlen)
 cdef parsedString read_string(const unsigned char[:] buf,
-        const unsigned int maxlen)
+        const unsigned int maxlen, int addNullTerm=*)
 cdef parsedNumericArrayBlock read_numeric_array(const unsigned char[:] buf,
         const unsigned int maxlen)
 

--- a/src/pyavro_stardust/baseavro.pxd
+++ b/src/pyavro_stardust/baseavro.pxd
@@ -1,20 +1,22 @@
 from libcpp.vector cimport vector
 
 cdef struct parsedString:
-    int toskip
-    int strlen
+    unsigned int toskip
+    unsigned int strlen
     unsigned char *start
 
 cdef struct parsedNumericArrayBlock:
-    int totalsize
-    int blockcount
+    unsigned int totalsize
+    unsigned int blockcount
     long *values
 
 
-cdef (int, long) read_long(const unsigned char[:] buf, const int maxlen)
-cdef parsedString read_string(const unsigned char[:] buf, const int maxlen)
+cdef (unsigned int, long) read_long(const unsigned char[:] buf,
+        const unsigned int maxlen)
+cdef parsedString read_string(const unsigned char[:] buf,
+        const unsigned int maxlen)
 cdef parsedNumericArrayBlock read_numeric_array(const unsigned char[:] buf,
-        const int maxlen)
+        const unsigned int maxlen)
 
 cdef class AvroRecord:
 
@@ -23,20 +25,20 @@ cdef class AvroRecord:
     cdef long **attributes_na
     cdef long *attributes_na_sizes
     cdef unsigned int sizeinbuf
-    cdef int stringcount
-    cdef int numcount
-    cdef int numarraycount
+    cdef unsigned int stringcount
+    cdef unsigned int numcount
+    cdef unsigned int numarraycount
 
-    cdef int parseNumeric(self, const unsigned char[:] buf, const int maxlen,
-        int attrind)
-    cpdef long getNumeric(self, int attrind)
-    cpdef str getString(self, int attrind)
-    cpdef unsigned int getRecordSizeInBuffer(self)
-    cdef int parseNumericArray(self, const unsigned char[:] buf,
-            const int maxlen, int attrind)
-    cdef int parseString(self, const unsigned char[:] buf, const int maxlen,
-        int attrind)
-    cpdef vector[long] getNumericArray(self, int attrind)
+    cdef int parseNumeric(self, const unsigned char[:] buf,
+        const unsigned int maxlen, const int attrind)
+    cpdef long getNumeric(self, const int attrind)
+    cpdef str getString(self, const int attrind)
+    cdef unsigned int getRecordSizeInBuffer(self)
+    cdef unsigned int parseNumericArray(self, const unsigned char[:] buf,
+            const unsigned int maxlen, const int attrind)
+    cdef unsigned int parseString(self, const unsigned char[:] buf,
+            const unsigned int maxlen, const int attrind)
+    cpdef vector[long] getNumericArray(self, const int attrind)
     cpdef void resetRecord(self)
 
 
@@ -52,7 +54,8 @@ cdef class AvroReader:
 
     cpdef void _readAvroFileHeader(self)
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
-                 const int maxlen)
+                 const unsigned int maxlen)
     cdef AvroRecord _getNextRecord(self)
+    cpdef void perAvroRecord(self, func, userarg=*)
 
 # vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/pyavro_stardust/baseavro.pxd
+++ b/src/pyavro_stardust/baseavro.pxd
@@ -89,6 +89,7 @@ cdef class AvroReader:
     cdef bytearray bufrin
     cdef bytes unzipped
     cdef AvroRecord currentrec
+    cdef dict schemajson
 
     cpdef void _readAvroFileHeader(self)
     cdef int _parseNextRecord(self, const unsigned char[:] buf,

--- a/src/pyavro_stardust/baseavro.pyx
+++ b/src/pyavro_stardust/baseavro.pyx
@@ -111,7 +111,7 @@ cdef parsedNumericArrayBlock read_numeric_array(const unsigned char[:] buf,
         arr.values = NULL
         return arr
 
-    arr.values = <long *>PyMem_Malloc(sizeof(long) * arr.blockcount)
+    arr.values = <long *>PyMem_Malloc(sizeof(long) * blockcount)
 
     for i in range(blockcount):
         skip, arrayitem = read_long(buf[arr.totalsize:], maxlen - arr.totalsize)

--- a/src/pyavro_stardust/baseavro.pyx
+++ b/src/pyavro_stardust/baseavro.pyx
@@ -46,7 +46,7 @@ cdef (unsigned int, long) read_long(const unsigned char[:] buf,
     cdef unsigned long b
     cdef unsigned long n
 
-    if maxlen == 0:
+    if maxlen == 0 or buf.size == 0:
         return 0,0
 
     b = buf[0]

--- a/src/pyavro_stardust/baseavro.pyx
+++ b/src/pyavro_stardust/baseavro.pyx
@@ -1,3 +1,37 @@
+# This software is Copyright (C) 2021 The Regents of the University of
+# California. All Rights Reserved. Permission to copy, modify, and distribute
+# this software and its documentation for educational, research and non-profit
+# purposes, without fee, and without a written agreement is hereby granted,
+# provided that the above copyright notice, this paragraph and the following
+# three paragraphs appear in all copies. Permission to make commercial use of
+# this software may be obtained by contacting:
+#
+# Office of Innovation and Commercialization
+# 9500 Gilman Drive, Mail Code 0910
+# University of California
+# La Jolla, CA 92093-0910
+# (858) 534-5815
+# invent@ucsd.edu
+#
+# This software program and documentation are copyrighted by The Regents of the
+# University of California. The software program and documentation are supplied
+# "as is", without any accompanying services from The Regents. The Regents does
+# not warrant that the operation of the program will be uninterrupted or
+# error-free. The end-user understands that the program was developed for
+# research purposes and is advised not to rely exclusively on the program for
+# any reason.
+#
+# IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE. THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+# HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
+# OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
 # cython: language_level=3
 from libc.string cimport memcpy
 from libcpp.vector cimport vector

--- a/src/pyavro_stardust/baseavro.pyx
+++ b/src/pyavro_stardust/baseavro.pyx
@@ -133,6 +133,7 @@ cdef class AvroRecord:
         self.stringcount = 0
         self.numcount = 0
         self.numarraycount = 0
+        self.schemaversion = 0
 
     def __init__(self, numeric, strings, numarrays):
         cdef unsigned int i
@@ -297,6 +298,9 @@ cdef class AvroRecord:
                     self.attributes_na[i] = NULL
 
 
+    cpdef void setSchemaVersion(self, const unsigned int schemaversion):
+        self.schemaversion = schemaversion
+
 cdef class AvroReader:
     def __init__(self, filepath):
         self.filepath = filepath
@@ -308,6 +312,7 @@ cdef class AvroReader:
         self.unzip_offset = 0
         self.currentrec = None
         self.schemajson = None
+        self.schemaversion = 0
 
     def _readMore(self):
         try:

--- a/src/pyavro_stardust/baseavro.pyx
+++ b/src/pyavro_stardust/baseavro.pyx
@@ -438,6 +438,10 @@ cdef class AvroReader:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cpdef void perAvroRecord(self, func, userarg=None):
+        if (self.fh == None):
+            print("You must call the start method before trying to read records!")
+            return
+
         cdef unsigned int offset, fullsize
         cdef unsigned int offinc
         cdef long blockcnt, blocksize
@@ -496,6 +500,70 @@ cdef class AvroReader:
 
             self.bufrin = self.bufrin[self.nextblock:]
             self.nextblock = 0
+
+    def dumpAvroRecords(self):
+        if (self.fh == None):
+            print("You must call the start method before trying to read records!")
+
+        cdef unsigned int offset, fullsize
+        cdef unsigned int offinc
+        cdef long blockcnt, blocksize
+        cdef AvroRecord nextrec
+
+        while self.syncmarker is None:
+            self._readAvroFileHeader()
+
+        while 1:
+            offset = self.nextblock
+            fullsize = len(self.bufrin) - self.nextblock
+
+            offinc, blockcnt = read_long(self.bufrin[offset:],
+                    fullsize - offset)
+            if offinc == 0:
+                if self._readMore() == 0:
+                    break
+                continue
+            offset += offinc
+            offinc, blocksize = read_long(self.bufrin[offset:],
+                    fullsize - offset)
+            if offinc == 0:
+                if self._readMore() == 0:
+                    break
+                continue
+
+            offset += offinc
+
+            content = self.bufrin[offset: offset + blocksize]
+            if len(content) < blocksize or \
+                    len(self.bufrin[offset + blocksize:]) < 16:
+                if self._readMore() == 0:
+                    break
+                continue
+
+            try:
+                self.unzipped = zlib.decompress(content, -15)
+                self.unzip_offset = 0
+            except zlib.error:
+                return
+
+            nextrec = self._getNextRecord()
+            while nextrec is not None:
+                yield nextrec
+                nextrec = self._getNextRecord()
+
+            offset += blocksize
+
+            #assert(self.bufrin[offset: offset+16] == self.syncmarker)
+
+            self.nextblock = offset + 16
+
+            if self.nextblock >= len(self.bufrin):
+                if self._readMore() == 0:
+                    break
+
+            self.bufrin = self.bufrin[self.nextblock:]
+            self.nextblock = 0
+
 
 
 

--- a/src/pyavro_stardust/flowtuple3.pxd
+++ b/src/pyavro_stardust/flowtuple3.pxd
@@ -30,7 +30,7 @@ cdef class AvroFlowtuple3(AvroRecord):
 
 cdef class AvroFlowtuple3Reader(AvroReader):
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
-            const int maxlen)
+            const unsigned int maxlen)
 
 
 # vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/pyavro_stardust/flowtuple3.pyx
+++ b/src/pyavro_stardust/flowtuple3.pyx
@@ -1,3 +1,37 @@
+# This software is Copyright (C) 2021 The Regents of the University of
+# California. All Rights Reserved. Permission to copy, modify, and distribute
+# this software and its documentation for educational, research and non-profit
+# purposes, without fee, and without a written agreement is hereby granted,
+# provided that the above copyright notice, this paragraph and the following
+# three paragraphs appear in all copies. Permission to make commercial use of
+# this software may be obtained by contacting:
+#
+# Office of Innovation and Commercialization
+# 9500 Gilman Drive, Mail Code 0910
+# University of California
+# La Jolla, CA 92093-0910
+# (858) 534-5815
+# invent@ucsd.edu
+#
+# This software program and documentation are copyrighted by The Regents of the
+# University of California. The software program and documentation are supplied
+# "as is", without any accompanying services from The Regents. The Regents does
+# not warrant that the operation of the program will be uninterrupted or
+# error-free. The end-user understands that the program was developed for
+# research purposes and is advised not to rely exclusively on the program for
+# any reason.
+#
+# IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE. THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+# HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
+# OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
 # cython: language_level=3
 cimport cython
 from pyavro_stardust.baseavro cimport AvroRecord, read_long, read_string, \

--- a/src/pyavro_stardust/flowtuple3.pyx
+++ b/src/pyavro_stardust/flowtuple3.pyx
@@ -55,9 +55,9 @@ cdef class AvroFlowtuple3Reader(AvroReader):
         self.currentrec = AvroFlowtuple3()
 
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
-            const int maxlen):
+            const unsigned int maxlen):
 
-        cdef int offset, offinc
+        cdef unsigned int offset, offinc
         cdef Flowtuple3AttributeNum i
         cdef Flowtuple3AttributeStr j
 

--- a/src/pyavro_stardust/flowtuple3.pyx
+++ b/src/pyavro_stardust/flowtuple3.pyx
@@ -7,7 +7,7 @@ from pyavro_stardust.baseavro cimport AvroRecord, read_long, read_string, \
 cdef class AvroFlowtuple3(AvroRecord):
 
     def __init__(self):
-        super().__init__(ATTR_FT3_ASN + 1, ATTR_FT3_NETACQ_COUNTRY + 1)
+        super().__init__(ATTR_FT3_ASN + 1, ATTR_FT3_NETACQ_COUNTRY + 1, 0)
 
     def __str__(self):
         return "%u %08x %08x %u %u %u %u %u %u %s %s %u" % \

--- a/src/pyavro_stardust/flowtuple4.pxd
+++ b/src/pyavro_stardust/flowtuple4.pxd
@@ -1,3 +1,37 @@
+# This software is Copyright (C) 2021 The Regents of the University of
+# California. All Rights Reserved. Permission to copy, modify, and distribute
+# this software and its documentation for educational, research and non-profit
+# purposes, without fee, and without a written agreement is hereby granted,
+# provided that the above copyright notice, this paragraph and the following
+# three paragraphs appear in all copies. Permission to make commercial use of
+# this software may be obtained by contacting:
+#
+# Office of Innovation and Commercialization
+# 9500 Gilman Drive, Mail Code 0910
+# University of California
+# La Jolla, CA 92093-0910
+# (858) 534-5815
+# invent@ucsd.edu
+#
+# This software program and documentation are copyrighted by The Regents of the
+# University of California. The software program and documentation are supplied
+# "as is", without any accompanying services from The Regents. The Regents does
+# not warrant that the operation of the program will be uninterrupted or
+# error-free. The end-user understands that the program was developed for
+# research purposes and is advised not to rely exclusively on the program for
+# any reason.
+#
+# IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE. THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+# HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
+# OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
 import cython
 from pyavro_stardust.baseavro cimport AvroRecord, AvroReader
 

--- a/src/pyavro_stardust/flowtuple4.pxd
+++ b/src/pyavro_stardust/flowtuple4.pxd
@@ -50,6 +50,9 @@ cpdef enum Flowtuple4AttributeNum:
     ATTR_FT4_FIRST_SYN_LEN = 11
     ATTR_FT4_FIRST_TCP_RWIN = 12
     ATTR_FT4_ASN = 13
+    ATTR_FT4_SPOOFED_COUNT = 14
+    ATTR_FT4_MASSCAN_COUNT = 15
+    ATTR_FT4_LAST_NUMERIC = 16
 
 cpdef enum Flowtuple4AttributeStr:
     ATTR_FT4_MAXMIND_CONTINENT = 0

--- a/src/pyavro_stardust/flowtuple4.pxd
+++ b/src/pyavro_stardust/flowtuple4.pxd
@@ -44,6 +44,6 @@ cdef class AvroFlowtuple4(AvroRecord):
 
 cdef class AvroFlowtuple4Reader(AvroReader):
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
-            const int maxlen)
+            const unsigned int maxlen)
 
 # vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/pyavro_stardust/flowtuple4.pyx
+++ b/src/pyavro_stardust/flowtuple4.pyx
@@ -1,3 +1,37 @@
+# This software is Copyright (C) 2021 The Regents of the University of
+# California. All Rights Reserved. Permission to copy, modify, and distribute
+# this software and its documentation for educational, research and non-profit
+# purposes, without fee, and without a written agreement is hereby granted,
+# provided that the above copyright notice, this paragraph and the following
+# three paragraphs appear in all copies. Permission to make commercial use of
+# this software may be obtained by contacting:
+#
+# Office of Innovation and Commercialization
+# 9500 Gilman Drive, Mail Code 0910
+# University of California
+# La Jolla, CA 92093-0910
+# (858) 534-5815
+# invent@ucsd.edu
+#
+# This software program and documentation are copyrighted by The Regents of the
+# University of California. The software program and documentation are supplied
+# "as is", without any accompanying services from The Regents. The Regents does
+# not warrant that the operation of the program will be uninterrupted or
+# error-free. The end-user understands that the program was developed for
+# research purposes and is advised not to rely exclusively on the program for
+# any reason.
+#
+# IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE. THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+# HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
+# OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
 # cython: language_level=3
 cimport cython
 from pyavro_stardust.baseavro cimport AvroRecord, AvroReader

--- a/src/pyavro_stardust/flowtuple4.pyx
+++ b/src/pyavro_stardust/flowtuple4.pyx
@@ -54,7 +54,8 @@ cdef class AvroFlowtuple4(AvroRecord):
         }
 
         if needarrays:
-
+            # XXX this feels like it could be faster, but not sure how
+            # to improve this
             ttls = self.getNumericArray(<int>ATTR_FT4_COMMON_TTLS)
             ttl_freqs = self.getNumericArray(<int>ATTR_FT4_COMMON_TTL_FREQS)
             for i in range(ttls.size()):
@@ -96,8 +97,8 @@ cdef class AvroFlowtuple4Reader(AvroReader):
         self.currentrec = AvroFlowtuple4()
 
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
-            const int maxlen):
-        cdef int offset, offinc
+            const unsigned int maxlen):
+        cdef unsigned int offset, offinc
         cdef Flowtuple4AttributeNum i
         cdef Flowtuple4AttributeStr j
         cdef Flowtuple4AttributeNumArray k

--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -1,3 +1,37 @@
+# This software is Copyright (C) 2021 The Regents of the University of
+# California. All Rights Reserved. Permission to copy, modify, and distribute
+# this software and its documentation for educational, research and non-profit
+# purposes, without fee, and without a written agreement is hereby granted,
+# provided that the above copyright notice, this paragraph and the following
+# three paragraphs appear in all copies. Permission to make commercial use of
+# this software may be obtained by contacting:
+#
+# Office of Innovation and Commercialization
+# 9500 Gilman Drive, Mail Code 0910
+# University of California
+# La Jolla, CA 92093-0910
+# (858) 534-5815
+# invent@ucsd.edu
+#
+# This software program and documentation are copyrighted by The Regents of the
+# University of California. The software program and documentation are supplied
+# "as is", without any accompanying services from The Regents. The Regents does
+# not warrant that the operation of the program will be uninterrupted or
+# error-free. The end-user understands that the program was developed for
+# research purposes and is advised not to rely exclusively on the program for
+# any reason.
+#
+# IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE. THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+# HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
+# OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
 cimport cython
 from pyavro_stardust.baseavro cimport AvroRecord, AvroReader, parsedString
 

--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -1,0 +1,39 @@
+import cython
+from pyavro_stardust.baseavro cimport AvroRecord, AvroReader, parsedString
+
+cpdef enum RsdosAttribute:
+    ATTR_RSDOS_TIMESTAMP = 0
+    ATTR_RSDOS_PACKET_LEN = 1
+    ATTR_RSDOS_TARGET_IP = 2
+    ATTR_RSDOS_TARGET_PROTOCOL = 3
+    ATTR_RSDOS_ATTACKER_IP_CNT = 4
+    ATTR_RSDOS_ATTACK_PORT_CNT = 5
+    ATTR_RSDOS_TARGET_PORT_CNT = 6
+    ATTR_RSDOS_PACKET_CNT = 7
+    ATTR_RSDOS_ICMP_MISMATCHES = 8
+    ATTR_RSDOS_BYTE_CNT = 9
+    ATTR_RSDOS_MAX_PPM_INTERVAL = 10
+    ATTR_RSDOS_START_TIME_SEC = 11
+    ATTR_RSDOS_START_TIME_USEC = 12
+    ATTR_RSDOS_LATEST_TIME_SEC = 13
+    ATTR_RSDOS_LATEST_TIME_USEC = 14
+    ATTR_RSDOS_LAST_ATTRIBUTE = 15
+
+@cython.final
+cdef class AvroRsdos(AvroRecord):
+
+    cdef unsigned char *packetcontent
+    cdef public int pktcontentlen
+
+    cpdef dict asDict(self)
+    cpdef void resetRecord(self)
+    cdef void setRsdosPacketString(self, parsedString astr)
+    cpdef bytes getRsdosPacketString(self)
+
+@cython.final
+cdef class AvroRsdosReader(AvroReader):
+    cdef int _parseNextRecord(self, const unsigned char[:] buf,
+            const int maxlen)
+
+
+# vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -51,20 +51,25 @@ cpdef enum RsdosAttribute:
     ATTR_RSDOS_START_TIME_USEC = 12
     ATTR_RSDOS_LATEST_TIME_SEC = 13
     ATTR_RSDOS_LATEST_TIME_USEC = 14
-    ATTR_RSDOS_LAST_ATTRIBUTE = 15
+    ATTR_RSDOS_FIRST_ATTACK_PORT = 15
+    ATTR_RSDOS_FIRST_TARGET_PORT = 16
+    ATTR_RSDOS_LAST_ATTRIBUTE = 17
 
 cdef class AvroRsdos(AvroRecord):
 
     cdef unsigned char *packetcontent
     cdef public unsigned int pktcontentlen
+    cdef public unsigned int schemaversion
 
     cpdef dict asDict(self)
+    cpdef void setSchemaVersion(self, const unsigned int schemaversion)
     cpdef void resetRecord(self)
     cpdef bytes getRsdosPacketString(self)
     cpdef int setRsdosPacketString(self, const unsigned char[:] buf,
             const unsigned int maxlen)
 
 cdef class AvroRsdosReader(AvroReader):
+    cdef unsigned int schemaversion
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
             const unsigned int maxlen)
 

--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -64,10 +64,8 @@ cdef class AvroRsdos(AvroRecord):
 
     cdef unsigned char *packetcontent
     cdef public unsigned int pktcontentlen
-    cdef public unsigned int schemaversion
 
     cpdef dict asDict(self)
-    cpdef void setSchemaVersion(self, const unsigned int schemaversion)
     cpdef void resetRecord(self)
     cpdef bytes getRsdosPacketString(self)
     cpdef unsigned int getRsdosPacketSize(self)
@@ -75,7 +73,6 @@ cdef class AvroRsdos(AvroRecord):
             const unsigned int maxlen)
 
 cdef class AvroRsdosReader(AvroReader):
-    cdef unsigned int schemaversion
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
             const unsigned int maxlen)
 

--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -65,6 +65,7 @@ cdef class AvroRsdos(AvroRecord):
     cpdef void setSchemaVersion(self, const unsigned int schemaversion)
     cpdef void resetRecord(self)
     cpdef bytes getRsdosPacketString(self)
+    cpdef unsigned int getRsdosPacketSize(self)
     cpdef int setRsdosPacketString(self, const unsigned char[:] buf,
             const unsigned int maxlen)
 

--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -55,6 +55,11 @@ cpdef enum RsdosAttribute:
     ATTR_RSDOS_FIRST_TARGET_PORT = 16
     ATTR_RSDOS_LAST_ATTRIBUTE = 17
 
+cpdef enum RsdosAttributeStirng:
+    ATTR_RSDOS_MAXMIND_CONTINENT = 0
+    ATTR_RSDOS_MAXMIND_COUNTRY = 1
+    ATTR_RSDOS_LAST_STRING_ATTRIBUTE = 2
+
 cdef class AvroRsdos(AvroRecord):
 
     cdef unsigned char *packetcontent

--- a/src/pyavro_stardust/rsdos.pxd
+++ b/src/pyavro_stardust/rsdos.pxd
@@ -1,4 +1,4 @@
-import cython
+cimport cython
 from pyavro_stardust.baseavro cimport AvroRecord, AvroReader, parsedString
 
 cpdef enum RsdosAttribute:
@@ -19,21 +19,20 @@ cpdef enum RsdosAttribute:
     ATTR_RSDOS_LATEST_TIME_USEC = 14
     ATTR_RSDOS_LAST_ATTRIBUTE = 15
 
-@cython.final
 cdef class AvroRsdos(AvroRecord):
 
     cdef unsigned char *packetcontent
-    cdef public int pktcontentlen
+    cdef public unsigned int pktcontentlen
 
     cpdef dict asDict(self)
     cpdef void resetRecord(self)
-    cdef void setRsdosPacketString(self, parsedString astr)
     cpdef bytes getRsdosPacketString(self)
+    cpdef int setRsdosPacketString(self, const unsigned char[:] buf,
+            const unsigned int maxlen)
 
-@cython.final
 cdef class AvroRsdosReader(AvroReader):
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
-            const int maxlen)
+            const unsigned int maxlen)
 
 
 # vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -45,6 +45,7 @@ cdef class AvroRsdos(AvroRecord):
         super().__init__(ATTR_RSDOS_LAST_ATTRIBUTE, 0, 0)
         self.pktcontentlen = 0
         self.packetcontent = NULL
+        self.schemaversion = 1
 
     def __str__(self):
         return "%u %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u" % \
@@ -65,12 +66,14 @@ cdef class AvroRsdos(AvroRecord):
                  self.pktcontentlen)
 
     cpdef dict asDict(self):
+        cdef dict result
+
         if self.pktcontentlen == 0:
             initpkt = None
         else:
             initpkt = self.getRsdosPacketString()
 
-        return {
+        result = {
             "timestamp": self.attributes_l[<int>ATTR_RSDOS_TIMESTAMP],
             "start_time_sec": self.attributes_l[<int>ATTR_RSDOS_START_TIME_SEC],
             "start_time_usec": self.attributes_l[<int>ATTR_RSDOS_START_TIME_USEC],
@@ -88,6 +91,12 @@ cdef class AvroRsdos(AvroRecord):
             "icmp_mismatches": self.attributes_l[<int>ATTR_RSDOS_ICMP_MISMATCHES],
             "initial_packet": initpkt,
         }
+
+        if self.schemaversion == 2:
+            result['first_attack_port'] = self.attributes_l[<int>ATTR_RSDOS_FIRST_ATTACK_PORT]
+            result['first_target_port'] = self.attributes_l[<int>ATTR_RSDOS_FIRST_TARGET_PORT]
+
+        return result
 
 
     cpdef void resetRecord(self):
@@ -112,26 +121,46 @@ cdef class AvroRsdos(AvroRecord):
         self.sizeinbuf += astr.toskip + astr.strlen
         return 1
 
+    cpdef void setSchemaVersion(self, const unsigned int schemaversion):
+        self.schemaversion = schemaversion
+
 @cython.final
 cdef class AvroRsdosReader(AvroReader):
 
     def __init__(self, filepath):
         super().__init__(filepath)
         self.currentrec = AvroRsdos()
+        self.schemaversion = 0
 
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
             const unsigned int maxlen):
 
         cdef unsigned int offset, offinc
         cdef RsdosAttribute i
+        cdef unsigned int maxattr
 
         if maxlen == 0:
             return 0
         offset = 0
 
-        self.currentrec.resetRecord()
 
-        for i in range(0, ATTR_RSDOS_LATEST_TIME_USEC + 1):
+        if self.schemaversion == 0:
+            self.schemaversion = 1
+            for f in self.schemajson['fields']:
+                if "first_attack_port" == f['name']:
+                    self.schemaversion = 2
+                    break
+            self.currentrec.setSchemaVersion(self.schemaversion)
+
+        if self.schemaversion == 1:
+            maxattr = ATTR_RSDOS_LATEST_TIME_USEC + 1
+        elif self.schemaversion == 2:
+            maxattr = ATTR_RSDOS_LAST_ATTRIBUTE
+        else:
+            return 0
+
+        self.currentrec.resetRecord()
+        for i in range(0, maxattr):
             offinc = self.currentrec.parseNumeric(buf[offset:],
                     maxlen - offset, i)
             if offinc == 0:

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -1,5 +1,39 @@
-
 # cython: language_level=3
+
+# This software is Copyright (C) 2021 The Regents of the University of
+# California. All Rights Reserved. Permission to copy, modify, and distribute
+# this software and its documentation for educational, research and non-profit
+# purposes, without fee, and without a written agreement is hereby granted,
+# provided that the above copyright notice, this paragraph and the following
+# three paragraphs appear in all copies. Permission to make commercial use of
+# this software may be obtained by contacting:
+#
+# Office of Innovation and Commercialization
+# 9500 Gilman Drive, Mail Code 0910
+# University of California
+# La Jolla, CA 92093-0910
+# (858) 534-5815
+# invent@ucsd.edu
+#
+# This software program and documentation are copyrighted by The Regents of the
+# University of California. The software program and documentation are supplied
+# "as is", without any accompanying services from The Regents. The Regents does
+# not warrant that the operation of the program will be uninterrupted or
+# error-free. The end-user understands that the program was developed for
+# research purposes and is advised not to rely exclusively on the program for
+# any reason.
+#
+# IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE. THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED
+# HEREUNDER IS ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO
+# OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+# MODIFICATIONS.
+
 cimport cython
 from cpython.mem cimport PyMem_Free
 from pyavro_stardust.baseavro cimport AvroRecord, read_long, read_string, \

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -49,7 +49,25 @@ cdef class AvroRsdos(AvroRecord):
         self.schemaversion = 1
 
     def __str__(self):
-        return "%u %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u %s %s" % \
+        if self.schemaversion == 1:
+            return "%u v1 %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u ?? ??" % \
+                    (self.attributes_l[<int>ATTR_RSDOS_TIMESTAMP], \
+                     self.attributes_l[<int>ATTR_RSDOS_START_TIME_SEC],
+                     self.attributes_l[<int>ATTR_RSDOS_START_TIME_USEC],
+                     self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_SEC],
+                     self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_USEC],
+                     self.attributes_l[<int>ATTR_RSDOS_TARGET_IP],
+                     self.attributes_l[<int>ATTR_RSDOS_TARGET_PROTOCOL],
+                     self.attributes_l[<int>ATTR_RSDOS_PACKET_LEN],
+                     self.attributes_l[<int>ATTR_RSDOS_ATTACKER_IP_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_ATTACK_PORT_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_TARGET_PORT_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_PACKET_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_BYTE_CNT],
+                     self.attributes_l[<int>ATTR_RSDOS_MAX_PPM_INTERVAL],
+                     self.getRsdosPacketSize())
+
+        return "%u v2 %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u %s %s" % \
                 (self.attributes_l[<int>ATTR_RSDOS_TIMESTAMP], \
                  self.attributes_l[<int>ATTR_RSDOS_START_TIME_SEC],
                  self.attributes_l[<int>ATTR_RSDOS_START_TIME_USEC],
@@ -65,8 +83,8 @@ cdef class AvroRsdos(AvroRecord):
                  self.attributes_l[<int>ATTR_RSDOS_BYTE_CNT],
                  self.attributes_l[<int>ATTR_RSDOS_MAX_PPM_INTERVAL],
                  self.getRsdosPacketSize(),
-                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_CONTINENT],
-                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_COUNTRY])
+                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_CONTINENT].decode('utf-8'),
+                 self.attributes_s[<int>ATTR_RSDOS_MAXMIND_COUNTRY].decode('utf-8'))
 
     cpdef dict asDict(self):
         cdef dict result
@@ -96,6 +114,8 @@ cdef class AvroRsdos(AvroRecord):
         }
 
         if self.schemaversion == 2:
+            del(result["attacker_count"])
+            result["attacker_slash16_count"] = self.attributes_l[<int>ATTR_RSDOS_ATTACKER_IP_CNT]
             result['first_attack_port'] = self.attributes_l[<int>ATTR_RSDOS_FIRST_ATTACK_PORT]
             result['first_target_port'] = self.attributes_l[<int>ATTR_RSDOS_FIRST_TARGET_PORT]
             result['maxmind_continent'] = self.attributes_s[<int>ATTR_RSDOS_MAXMIND_CONTINENT]

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -1,0 +1,105 @@
+
+# cython: language_level=3
+cimport cython
+from pyavro_stardust.baseavro cimport AvroRecord, read_long, read_string, \
+        AvroReader, parsedString
+
+@cython.final
+cdef class AvroRsdos(AvroRecord):
+    def __init__(self):
+        super().__init__(ATTR_RSDOS_LAST_ATTRIBUTE, 0, 0)
+        self.pktcontentlen = 0
+        self.packetcontent = NULL
+
+    def __str__(self):
+        return "%u %u.%06u %u.%06u %08x %u %u %u %u %u %u %u %u %u" % \
+                (self.attributes_l[<int>ATTR_RSDOS_TIMESTAMP], \
+                 self.attributes_l[<int>ATTR_RSDOS_START_TIME_SEC],
+                 self.attributes_l[<int>ATTR_RSDOS_START_TIME_USEC],
+                 self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_SEC],
+                 self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_USEC],
+                 self.attributes_l[<int>ATTR_RSDOS_TARGET_IP],
+                 self.attributes_l[<int>ATTR_RSDOS_TARGET_PROTOCOL],
+                 self.attributes_l[<int>ATTR_RSDOS_PACKET_LEN],
+                 self.attributes_l[<int>ATTR_RSDOS_ATTACKER_IP_CNT],
+                 self.attributes_l[<int>ATTR_RSDOS_ATTACK_PORT_CNT],
+                 self.attributes_l[<int>ATTR_RSDOS_TARGET_PORT_CNT],
+                 self.attributes_l[<int>ATTR_RSDOS_PACKET_CNT],
+                 self.attributes_l[<int>ATTR_RSDOS_BYTE_CNT],
+                 self.attributes_l[<int>ATTR_RSDOS_MAX_PPM_INTERVAL],
+                 self.pktcontentlen)
+
+    cpdef dict asDict(self):
+        if self.pktcontentlen == 0:
+            initpkt = None
+        else:
+            initpkt = <bytes>self.packetcontent
+
+        return {
+            "timestamp": self.attributes_l[<int>ATTR_RSDOS_TIMESTAMP],
+            "start_time_sec": self.attributes_l[<int>ATTR_RSDOS_START_TIME_SEC],
+            "start_time_usec": self.attributes_l[<int>ATTR_RSDOS_START_TIME_USEC],
+            "latest_time_sec": self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_SEC],
+            "latest_time_usec": self.attributes_l[<int>ATTR_RSDOS_LATEST_TIME_USEC],
+            "target_ip": self.attributes_l[<int>ATTR_RSDOS_TARGET_IP],
+            "target_protocol": self.attributes_l[<int>ATTR_RSDOS_TARGET_PROTOCOL],
+            "packet_len": self.attributes_l[<int>ATTR_RSDOS_PACKET_LEN],
+            "attacker_count": self.attributes_l[<int>ATTR_RSDOS_ATTACKER_IP_CNT],
+            "attack_port_count": self.attributes_l[<int>ATTR_RSDOS_ATTACK_PORT_CNT],
+            "target_port_count": self.attributes_l[<int>ATTR_RSDOS_TARGET_PORT_CNT],
+            "packet_count": self.attributes_l[<int>ATTR_RSDOS_PACKET_CNT],
+            "byte_count": self.attributes_l[<int>ATTR_RSDOS_BYTE_CNT],
+            "max_ppm_interval": self.attributes_l[<int>ATTR_RSDOS_MAX_PPM_INTERVAL],
+            "icmp_mismatches": self.attributes_l[<int>ATTR_RSDOS_ICMP_MISMATCHES],
+            "initial_packet": initpkt,
+        }
+
+
+    cpdef void resetRecord(self):
+        self.pktcontentlen = 0
+        super(AvroRsdos, self).resetRecord()
+
+    cdef void setRsdosPacketString(self, parsedString astr):
+        self.packetcontent = astr.start
+        self.pktcontentlen = astr.strlen
+
+    cpdef bytes getRsdosPacketString(self):
+        return <bytes>self.packetcontent
+
+@cython.final
+cdef class AvroRsdosReader(AvroReader):
+
+    def __init__(self, filepath):
+        super().__init__(filepath)
+        self.currentrec = AvroRsdos()
+
+    cdef int _parseNextRecord(self,  const unsigned char[:] buf,
+            const int maxlen):
+
+        cdef int offset, offinc
+        cdef RsdosAttribute i
+        cdef parsedString astr
+
+        if maxlen == 0:
+            return 0
+        offset = 0
+
+        self.currentrec.resetRecord()
+
+        for i in range(0, ATTR_RSDOS_LATEST_TIME_USEC + 1):
+            offinc = self.currentrec.parseNumeric(buf[offset:],
+                    maxlen - offset, i)
+            if offinc <= 0:
+                return 0
+            offset += offinc
+
+        astr = read_string(buf[offset:], maxlen - offset)
+        if astr.toskip == 0:
+            return 0
+
+        self.currentrec.setRsdosPacketString(astr)
+        self.currentrec.sizeinbuf += astr.toskip + astr.strlen
+        return 1
+
+
+# vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -63,12 +63,12 @@ cdef class AvroRsdos(AvroRecord):
                  self.attributes_l[<int>ATTR_RSDOS_PACKET_CNT],
                  self.attributes_l[<int>ATTR_RSDOS_BYTE_CNT],
                  self.attributes_l[<int>ATTR_RSDOS_MAX_PPM_INTERVAL],
-                 self.pktcontentlen)
+                 self.getRsdosPacketSize())
 
     cpdef dict asDict(self):
         cdef dict result
 
-        if self.pktcontentlen == 0:
+        if self.getRsdosPacketSize() == 0:
             initpkt = None
         else:
             initpkt = self.getRsdosPacketString()
@@ -106,12 +106,40 @@ cdef class AvroRsdos(AvroRecord):
         super(AvroRsdos, self).resetRecord()
 
     cpdef bytes getRsdosPacketString(self):
-        return <bytes>self.packetcontent[:self.pktcontentlen]
+        cdef unsigned int tagheadersize
+
+        tagheadersize = 0
+
+        # Ideally, we would be able to pull the size out of libtrace or
+        # libcorsaro, but for now we'll just have to hard-code the size here
+        if self.schemaversion == 1:
+            tagheadersize = 35 + (4 * 8)
+
+        if self.pktcontentlen <= tagheadersize:
+            return None
+
+        return <bytes>self.packetcontent[tagheadersize:self.pktcontentlen]
+
+    cpdef unsigned int getRsdosPacketSize(self):
+        cdef unsigned int tagheadersize
+
+        tagheadersize = 0
+
+        # Ideally, we would be able to pull the size out of libtrace or
+        # libcorsaro, but for now we'll just have to hard-code the size here
+        if self.schemaversion == 1:
+            tagheadersize = 35 + (4 * 8)
+
+        if self.pktcontentlen <= tagheadersize:
+            return 0
+
+        return self.pktcontentlen - tagheadersize
 
     cpdef int setRsdosPacketString(self, const unsigned char[:] buf,
             const unsigned int maxlen):
 
         cdef parsedString astr
+
 
         astr = read_string(buf, maxlen, addNullTerm=False)
         if astr.toskip == 0:

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -174,16 +174,12 @@ cdef class AvroRsdos(AvroRecord):
         self.sizeinbuf += astr.toskip + astr.strlen
         return 1
 
-    cpdef void setSchemaVersion(self, const unsigned int schemaversion):
-        self.schemaversion = schemaversion
-
 @cython.final
 cdef class AvroRsdosReader(AvroReader):
 
     def __init__(self, filepath):
         super().__init__(filepath)
         self.currentrec = AvroRsdos()
-        self.schemaversion = 0
 
     cdef int _parseNextRecord(self, const unsigned char[:] buf,
             const unsigned int maxlen):


### PR DESCRIPTION
The `dumpAvroRecords` method is nearly a clone of the `perAvroRecord` method except for the fact that it's a generator function instead of one that uses callbacks. This makes it easier to iterate over all records in an avro file using something like a `for in` loop rather than an asynchronous callback. Basic checking for whether the start method was called yet is also something that is implemented.