### PR TITLE
Add wandio options parameter

### DIFF
--- a/src/pyavro_stardust/baseavro.pxd
+++ b/src/pyavro_stardust/baseavro.pxd
@@ -93,6 +93,7 @@ cdef class AvroReader:
     cdef bytes unzipped
     cdef AvroRecord currentrec
     cdef dict schemajson
+    cdef dict options
 
     cpdef void _readAvroFileHeader(self)
     cdef int _parseNextRecord(self, const unsigned char[:] buf,

--- a/src/pyavro_stardust/baseavro.pyx
+++ b/src/pyavro_stardust/baseavro.pyx
@@ -302,7 +302,7 @@ cdef class AvroRecord:
         self.schemaversion = schemaversion
 
 cdef class AvroReader:
-    def __init__(self, filepath, options={}):
+    def __init__(self, filepath, options=None):
         self.filepath = filepath
         self.options = options
         self.syncmarker = None

--- a/src/pyavro_stardust/baseavro.pyx
+++ b/src/pyavro_stardust/baseavro.pyx
@@ -302,8 +302,9 @@ cdef class AvroRecord:
         self.schemaversion = schemaversion
 
 cdef class AvroReader:
-    def __init__(self, filepath):
+    def __init__(self, filepath, options={}):
         self.filepath = filepath
+        self.options = options
         self.syncmarker = None
         self.fh = None
         self.bufrin = bytearray()
@@ -397,7 +398,7 @@ cdef class AvroReader:
         saved = None
         while mode != 'fail':
             try:
-                self.fh = wandio.open(self.filepath, mode=mode)
+                self.fh = wandio.open(self.filepath, mode=mode, options=self.options)
             except ValueError as e:
                 if mode == 'rb':
                     mode = 'r'

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -177,8 +177,8 @@ cdef class AvroRsdos(AvroRecord):
 @cython.final
 cdef class AvroRsdosReader(AvroReader):
 
-    def __init__(self, filepath):
-        super().__init__(filepath)
+    def __init__(self, filepath, options={}):
+        super().__init__(filepath, options)
         self.currentrec = AvroRsdos()
 
     cdef int _parseNextRecord(self, const unsigned char[:] buf,

--- a/src/pyavro_stardust/rsdos.pyx
+++ b/src/pyavro_stardust/rsdos.pyx
@@ -177,7 +177,7 @@ cdef class AvroRsdos(AvroRecord):
 @cython.final
 cdef class AvroRsdosReader(AvroReader):
 
-    def __init__(self, filepath, options={}):
+    def __init__(self, filepath, options=None):
         super().__init__(filepath, options)
         self.currentrec = AvroRsdos()
 


### PR DESCRIPTION
Allows wandio options to be passed in when creating an AvroRsdosReader object to allow for accessing multiple swift projects in the same code.